### PR TITLE
Update documentation links to point to the new overview section

### DIFF
--- a/faa-workshop/guides/102-SAMOverview.md
+++ b/faa-workshop/guides/102-SAMOverview.md
@@ -34,7 +34,7 @@
 
 At its core, Agent Mesh addresses a fundamental challenge in AI development: connecting powerful AI models to the data and systems where they provide value. Rather than building monolithic AI applications, Agent Mesh allows you to create specialized agents that each excel at specific tasks and collaborate through standardized communication. These agents could be hosted on whatever runtime environment such as AgentCore, be in any region, use any LLM model such as those that are hosted on Bedrock, and leverage A2A protocol. 
 
-👉 [Explore the Solace Agent Mesh documentation](https://solacelabs.github.io/solace-agent-mesh/docs/documentation/getting-started)
+👉 [Explore the Solace Agent Mesh documentation](https://solacelabs.github.io/solace-agent-mesh/docs/documentation/overview)
 
 **Key Architectural Principles:**
 

--- a/solace-agent-mesh/README.md
+++ b/solace-agent-mesh/README.md
@@ -9,7 +9,7 @@ Welcome to the **Solace Agent Mesh** workshop! This repository contains comprehe
 ## Resources
 
 - [Solace Agent Mesh Githiub Repository](https://github.com/solacelabs/solace-agent-mesh)
-- [Solace Agent Mesh Docs](https://solacelabs.github.io/solace-agent-mesh/docs/documentation/getting-started/introduction/)
+- [Solace Agent Mesh Docs](https://solacelabs.github.io/solace-agent-mesh/docs/documentation/overview/introduction/)
 - [Solace Agent Mesh Core Plugins](https://github.com/SolaceLabs/solace-agent-mesh-core-plugins)
 - [Solace Agent Mesh Community Plugins](https://github.com/solacecommunity/solace-agent-mesh-plugins/)
 

--- a/solace-agent-mesh/guides/999-resources.md
+++ b/solace-agent-mesh/guides/999-resources.md
@@ -7,7 +7,7 @@
 ---
 
 **For questions or troubleshooting:**  
-Ask during the workshop or visit [Solace Agent Mesh Documentation](https://solacelabs.github.io/solace-agent-mesh/docs/documentation/getting-started/introduction/) or ask in [Solace Community](https://community.solace.com/c/solace-agent-mesh/16).
+Ask during the workshop or visit [Solace Agent Mesh Documentation](https://solacelabs.github.io/solace-agent-mesh/docs/documentation/overview/introduction/) or ask in [Solace Community](https://community.solace.com/c/solace-agent-mesh/16).
 
 ---
 * ⭐️ Take a moment to check out the open source repo and give it a star! [https://github.com/SolaceLabs/solace-agent-mesh](https://github.com/SolaceLabs/solace-agent-mesh)_


### PR DESCRIPTION
  ### What is the purpose of this change?
  
  Updates documentation links across the Solace Agent Mesh workshop guides to point to the new overview section, ensuring users are directed to the correct and up-to-date
   location.

  ### How is this accomplished?

  - Update documentation links to point to the new overview section